### PR TITLE
fix(theme): Use explicit 'light' value in localStorage

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -21,9 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
      * @returns {void}
      */
     const applyTheme = () => {
-        if (localStorage.getItem('theme') === 'dark') {
+        const theme = localStorage.getItem('theme');
+        if (theme === 'dark') {
             htmlEl.classList.add('dark');
         } else {
+            // Defaults to light theme
             htmlEl.classList.remove('dark');
         }
     };
@@ -35,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     const toggleTheme = () => {
         if (localStorage.getItem('theme') === 'dark') {
-            localStorage.removeItem('theme');
+            localStorage.setItem('theme', 'light');
         } else {
             localStorage.setItem('theme', 'dark');
         }


### PR DESCRIPTION
The theme toggling logic previously removed the 'theme' key from localStorage when switching to light mode. This created an implicit state where the absence of the key meant 'light' theme.

This change modifies the logic to explicitly set the theme value to 'light' in localStorage. This makes the theme state management more robust, explicit, and less prone to errors if other parts of the application need to read the theme value.