### PR TITLE
feat: Add image placeholders to index page cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,26 +80,28 @@
 
                         <div class="flex flex-col md:flex-row items-center justify-center gap-6">
                             <!-- Hookups Mode Card -->
-                            <div class="group w-80 h-96 p-6 bg-black bg-opacity-40 rounded-2xl shadow-lg backdrop-blur-lg border border-white border-opacity-20 transition-all duration-300 hover:scale-105 hover:shadow-2xl">
-                                <div class="flex flex-col justify-between h-full">
+                            <div class="group w-80 h-96 bg-black bg-opacity-40 rounded-2xl shadow-lg backdrop-blur-lg border border-white border-opacity-20 transition-all duration-300 hover:scale-105 hover:shadow-2xl overflow-hidden">
+                                <img src="https://via.placeholder.com/320x200/FF3B30/1A1A1A?text=Discreet" alt="Hookups" class="w-full h-1/2 object-cover">
+                                <div class="p-6 flex flex-col justify-between flex-1">
                                     <div>
                                         <h2 class="text-3xl font-bold text-hookups-accent mb-2">Hookups</h2>
                                         <p class="text-gray-300 mb-4">Discreet. Anonymous. Direct.</p>
                                     </div>
-                                    <a href="hookups.html" class="mt-auto px-8 py-3 bg-hookups-accent text-white font-bold rounded-full shadow-lg transform transition-transform duration-300 group-hover:scale-110">
+                                    <a href="hookups.html" class="mt-auto px-8 py-3 bg-hookups-accent text-white font-bold rounded-full shadow-lg transform transition-transform duration-300 group-hover:scale-110 self-center">
                                         Enter
                                     </a>
                                 </div>
                             </div>
 
                             <!-- Community Mode Card -->
-                            <div class="group w-80 h-96 p-6 bg-white bg-opacity-20 rounded-2xl shadow-lg backdrop-blur-lg border border-white border-opacity-20 transition-all duration-300 hover:scale-105 hover:shadow-2xl">
-                                 <div class="flex flex-col justify-between h-full">
+                            <div class="group w-80 h-96 bg-white bg-opacity-20 rounded-2xl shadow-lg backdrop-blur-lg border border-white border-opacity-20 transition-all duration-300 hover:scale-105 hover:shadow-2xl overflow-hidden">
+                                <img src="https://via.placeholder.com/320x200/FF9500/F5F5F7?text=Vibrant" alt="Community" class="w-full h-1/2 object-cover">
+                                <div class="p-6 flex flex-col justify-between flex-1">
                                     <div>
                                         <h2 class="text-3xl font-bold text-community-accent mb-2">Community</h2>
                                         <p class="text-gray-200 mb-4">Events. Groups. Culture.</p>
                                     </div>
-                                    <a href="community.html" class="mt-auto px-8 py-3 bg-community-accent text-white font-bold rounded-full shadow-lg transform transition-transform duration-300 group-hover:scale-110">
+                                    <a href="community.html" class="mt-auto px-8 py-3 bg-community-accent text-white font-bold rounded-full shadow-lg transform transition-transform duration-300 group-hover:scale-110 self-center">
                                         Explore
                                     </a>
                                 </div>


### PR DESCRIPTION
Adds placeholder images to the "Hookups" and "Community" cards on the main landing page to improve visual appeal.

The images are generated using via.placeholder.com and the card layout has been adjusted to accommodate them.