### PR TITLE
feat: Add background image to Hookups card

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,12 +80,12 @@
 
                         <div class="flex flex-col md:flex-row items-center justify-center gap-6">
                             <!-- Hookups Mode Card -->
-                            <div class="group w-80 h-96 bg-black bg-opacity-40 rounded-2xl shadow-lg backdrop-blur-lg border border-white border-opacity-20 transition-all duration-300 hover:scale-105 hover:shadow-2xl overflow-hidden">
-                                <img src="https://via.placeholder.com/320x200/FF3B30/1A1A1A?text=Discreet" alt="Hookups" class="w-full h-1/2 object-cover">
-                                <div class="p-6 flex flex-col justify-between flex-1">
+                            <div class="group relative w-80 h-96 rounded-2xl shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl overflow-hidden" style="background-image: url('https://i.imgur.com/TyhAOt9.png'); background-size: cover; background-position: center;">
+                                <div class="absolute inset-0 bg-black bg-opacity-50"></div> <!-- Overlay -->
+                                <div class="relative z-10 p-6 flex flex-col justify-between h-full text-white">
                                     <div>
                                         <h2 class="text-3xl font-bold text-hookups-accent mb-2">Hookups</h2>
-                                        <p class="text-gray-300 mb-4">Discreet. Anonymous. Direct.</p>
+                                        <p class="text-gray-200 mb-4">Discreet. Anonymous. Direct.</p>
                                     </div>
                                     <a href="hookups.html" class="mt-auto px-8 py-3 bg-hookups-accent text-white font-bold rounded-full shadow-lg transform transition-transform duration-300 group-hover:scale-110 self-center">
                                         Enter


### PR DESCRIPTION
Replaces the placeholder image on the "Hookups" card with a user-provided image, applied as a full background.

This change enhances the visual design of the main landing page by using a more engaging image for one of the primary navigation cards. An overlay has been added to ensure text legibility.