### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -95,7 +95,10 @@ const initializeMessaging = () => {
     if (messageText) {
       const messageEl = document.createElement('div');
       messageEl.className = 'flex justify-end';
-      messageEl.innerHTML = `<div class="bg-community-accent dark:bg-hookups-accent text-white p-3 rounded-lg max-w-lg">${messageText}</div>`;
+      const innerDiv = document.createElement('div');
+      innerDiv.className = 'bg-community-accent dark:bg-hookups-accent text-white p-3 rounded-lg max-w-lg';
+      innerDiv.textContent = messageText;
+      messageEl.appendChild(innerDiv);
       messageArea.appendChild(messageEl);
       messageInput.value = '';
       messageArea.scrollTop = messageArea.scrollHeight;


### PR DESCRIPTION
Potential fix for [https://github.com/Tshikwetamakole/Limpopo-Connect-/security/code-scanning/5](https://github.com/Tshikwetamakole/Limpopo-Connect-/security/code-scanning/5)

The best way to fix this vulnerability is to ensure that user-supplied text is never interpreted as HTML by the browser. Instead of using `innerHTML` to insert data that comes from users, insert it as plain text via the DOM API. This can be accomplished using `textContent` on a node and then styling/arranging it as needed.  
Specifically, for the message rendering—instead of interpolating the raw message into a string set via `innerHTML`, create a container div, apply classes, and set its `textContent` to the user message text.  
Update lines in `initializeMessaging` (especially the block at line 98) to:  
- Create a wrapper div  
- Set its class to the desired value  
- Set its `textContent` to the message text  
- Add that to the parent element

No external libraries are needed for this fix. All changes are in `src/scripts/ui.js`, in the `sendMessage` function definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
