### PR TITLE
Fix: Improve GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           cname: limpopoconnect.site
+          clean: true # Automatically remove deleted files
+          force_orphan: true # Create a new orphan branch each time to clean history
 
 


### PR DESCRIPTION
This PR improves the GitHub Pages deployment workflow by adding clean and force_orphan options to ensure a clean deployment each time. It also updates the base path configuration for better asset loading with the custom domain.